### PR TITLE
Update to work with MediaWiki 1.26.2

### DIFF
--- a/example.php
+++ b/example.php
@@ -6,12 +6,12 @@
  * YOU SHOULD PLACE THEM OUTSIDE THE DOCUMENT ROOT OF YOUR WEB SERVER!!!
  */
 
-define("MEDIAWIKI_PATH", "/var/lib/mediawiki-1.6.10/");
+define("MEDIAWIKI_PATH", "/var/lib/mediawiki-1.26.2/");
 
 /* Include our helper class */
 require_once "mediawiki-zhconverter.inc.php";
 
-/* Convert it, valid variants such as zh, zh-cn, zh-tw, zh-sg & zh-hk */
+/* Convert it, valid variants such as zh, zh-hans, zh-hant, zh-cn, zh-tw, zh-sg & zh-hk */
 echo MediaWikiZhConverter::convert("雪糕", "zh-tw") , ",";
 echo MediaWikiZhConverter::convert("記憶體", "zh-cn"), ",";
 echo MediaWikiZhConverter::convert("大卫·贝克汉姆", "zh-hk");

--- a/mediawiki-zhconverter.inc.php
+++ b/mediawiki-zhconverter.inc.php
@@ -135,6 +135,7 @@ class MediaWikiZhConverter {
             global $wgRequest, $wgMemc;
             global $wgLocalisationCacheConf, $wgDisabledVariants, $wgExtraLanguageNames;
             global $wgLangConvMemc, $wgMessageCacheType, $wgObjectCaches;
+            global $wgLanguageConverterCacheType, $wgMWLoggerDefaultSpi, $wgMainWANCache, $wgWANObjectCaches;
             $wgRequest = new WebRequest();
             $wgMemc = new FakeMemCachedClient;
 
@@ -143,20 +144,33 @@ class MediaWikiZhConverter {
             $wgDisabledVariants = array();
             $wgExtraLanguageNames = array();
             $wgLangConvMemc = new FakeMemCachedClient;
+            define('CACHE_NONE', 'FAKE');
             $wgObjectCaches = array(
                 'FAKE' => array( 'class' => 'FakeMemCachedClient' ),
             );
             $wgMessageCacheType = 'FAKE';
+            $wgLanguageConverterCacheType = 'FAKE';
+            $wgMainWANCache = 'FAKE';
+            $wgWANObjectCaches = array(
+                    'FAKE' => array(
+                            'class'         => 'WANObjectCache',
+                            'cacheId'       => 'FAKE',
+                            'pool'          => 'mediawiki-main-none',
+                            'relayerConfig' => array( 'class' => 'EventRelayerNull' )
+                    )
+            );
+            $wgMWLoggerDefaultSpi = array( 'class' => '\\MediaWiki\\Logger\\NullSpi' );
 
             require_once "includes/GlobalFunctions.php";
             require_once "includes/AutoLoader.php";
+            require_once "vendor/autoload.php";
 
             /* Switch for PHP4 and PHP5 version of MediaWiki */
             if (file_exists( MEDIAWIKI_PATH . "languages/LanguageZh.php")) {
                 require_once "languages/LanguageZh.php";
             } else {
                 require_once "languages/classes/LanguageZh.php";
-                require_once "includes/utils/StringUtils.php";
+                require_once "includes/libs/StringUtils.php";
             }
 
             $instance = new MediaWikiZhConverter();


### PR DESCRIPTION
Thanks for the library. Had to update paths and caches to make it work with the latest MediaWiki. Also, since now vendor libraries are extracted to a separate directory, there is now a call to `autoload.php`.
